### PR TITLE
fix Required `json` property not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "parse5": "^3.0.2",
     "polyserve": "^0.20.0",
     "raml-js-data-provider": "^0.1.0",
-    "raml-json-enhance-node": "^0.2.0",
+    "raml-json-enhance-node": "^0.3.0",
     "winston": "^2.3.1",
     "ws": "^3.1.0"
   },


### PR DESCRIPTION
when use 'api-console dev api.raml', an error thrown out :"Required `json` property not found".